### PR TITLE
added do-until loop to the Import GPG keys-task to take advantage of the round-robin dns of pool.sks-keyservers.net/keys.gnupg.net

### DIFF
--- a/ruby/rvm/tasks/main.yml
+++ b/ruby/rvm/tasks/main.yml
@@ -29,6 +29,9 @@
   register: rvm_import_gpg_keys_result
   sudo: yes
   sudo_user: "{{ rvm_user | default(app_user, true) }}"
+  until: rvm_import_gpg_keys_result.rc == 0
+  retries: 10
+  delay: 0
   when: rvm_gpg_keys_check.rc != 0
 
 - name: Alternative GPG keys


### PR DESCRIPTION
I'm not sure if this solves the issue you've been running into last Wednesday. Has it been one of the *rare cases* the [rvm docs](http://rvm.io/rvm/security) mention? What else could that be but a not responding server? 

We could maybe remove the `Alternative GPG keys`-task and should maybe remove the `ignore_errors`-option of the `Import GPG keys`-task but I'm also not sure.

If I'm not completely wrong the `Alternative GPG keys`-task does basically the same as the postgresql `Add repo key`-task so it is maybe not too insecure.