### PR TITLE
added rbenv role

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Provisioning:
 * **postgresql** install a PostgreSQL 9.3 database
 * **upstart/userjobs** enables Upstart userjobs
 * **ruby/rvm** installs a specific Ruby version with rvm
+* **ruby/rbenv** installs a specific Ruby version with rbenv
 * **ruby/postgresql** allow ruby to access postgresql
 * **rails/create-folders** prepares a folder for Rails releases
 * **rails/logrotate** create logrotate configuration for Rails logs

--- a/ruby/rbenv/README.md
+++ b/ruby/rbenv/README.md
@@ -1,0 +1,19 @@
+dresden-weekly.Rails/ruby/rbenv
+===============================
+
+This role installs [rbenv](https://github.com/sstephenson/rbenv/wiki/Why-rbenv%3F) for a given user and (re-)sets the *global* rbenv ruby version.
+
+Requirements
+------------
+
+Ubuntu 12.04 (Precise), Ubuntu 14.04 (Trusty), or CentOS 7
+
+Dependencies
+------------
+
+The user ("app_user") has to exist!
+
+Facts
+-----
+
+* **RUBY_PREFIX** - contains the command prefix required to run commands with the *default* ruby version. (Only required for non shell invocations compatible with the [rvm-role](../rvm/).)

--- a/ruby/rbenv/defaults/main.yml
+++ b/ruby/rbenv/defaults/main.yml
@@ -1,0 +1,16 @@
+rbenv_default: "{{ ruby_version }}"
+
+rbenv_user: "{{ app_user }}"
+
+rbenv_shell_rc: ~/.profile
+
+rbenv_rubies: []
+# tested with the following versions:
+# - 2.1.0
+# - 2.1.1
+# - 2.1.2
+# - 2.1.3
+# - 2.1.4
+# - 2.1.5
+# - 2.2.0
+# - 2.2.1

--- a/ruby/rbenv/tasks/Debian-packages.yml
+++ b/ruby/rbenv/tasks/Debian-packages.yml
@@ -1,0 +1,6 @@
+- name: Install Debian dependencies
+  apt:
+    pkg: "{{ item }}"
+    update_cache: yes
+    state: latest
+  with_items: rbenv_package_names

--- a/ruby/rbenv/tasks/RedHat-packages.yml
+++ b/ruby/rbenv/tasks/RedHat-packages.yml
@@ -1,0 +1,10 @@
+- name: Install EPEL repo
+  yum:
+    name: "{{ rbenv_epel_repo }}"
+    update_cache: yes
+
+- name: Install Redhat dependencies
+  yum:
+    pkg: "{{item}}"
+    update_cache: yes
+  with_items: rbenv_package_names

--- a/ruby/rbenv/tasks/main.yml
+++ b/ruby/rbenv/tasks/main.yml
@@ -1,0 +1,95 @@
+- include_vars: "{{ ansible_os_family }}.yml"
+
+- include: RedHat-packages.yml
+  when: ansible_os_family == "RedHat"
+- include: Debian-packages.yml
+  when: ansible_os_family == "Debian"
+
+- name: Install rbenv
+  git:
+    repo: https://github.com/sstephenson/rbenv.git
+    dest: ~/.rbenv
+    depth: 1
+  sudo: yes
+  sudo_user: "{{ rbenv_user }}"
+
+- name: Install ruby-build
+  git:
+    repo: https://github.com/sstephenson/ruby-build.git
+    dest: ~/.rbenv/plugins/ruby-build
+    depth: 1
+  sudo: yes
+  sudo_user: "{{ rbenv_user }}"
+
+- name: ensure {{ rbenv_shell_rc }}  exists
+  shell: touch {{ rbenv_shell_rc }}
+  args:
+    creates: "{{ rbenv_shell_rc }}"
+  sudo: true
+  sudo_user: "{{ rbenv_user }}"
+
+- name: Export RBENV_ROOT in {{ rbenv_shell_rc }}
+  lineinfile:
+    dest: "{{ rbenv_shell_rc }}"
+    regexp: "^export RBENV_ROOT="
+    line: "export RBENV_ROOT=~/.rbenv"
+  sudo: true
+  sudo_user: "{{ rbenv_user }}"
+
+- name: Put rbenv in users PATH in {{ rbenv_shell_rc }}
+  lineinfile:
+    dest: "{{ rbenv_shell_rc }}"
+    regexp: "^PATH=\\$PATH:\\$RBENV_ROOT/bin"
+    line: "PATH=$PATH:$RBENV_ROOT/bin"
+  sudo: true
+  sudo_user: "{{ rbenv_user }}"
+
+- name: Put $RBENV_ROOT/shims in users $PATH in {{ rbenv_shell_rc }}
+  lineinfile:
+    dest: "{{ rbenv_shell_rc }}"
+    regexp: "^PATH=\\$PATH:\\$RBENV_ROOT/shims"
+    line: "PATH=$PATH:$RBENV_ROOT/shims"
+  sudo: true
+  sudo_user: "{{ rbenv_user }}"
+
+- name: Install Rubies
+  shell: "{{ rbenv_ruby_configure_opts | default('') }} ~/.rbenv/bin/rbenv install {{ item }}"
+  args:
+    creates: "~/.rbenv/versions/{{ item }}"
+  sudo: yes
+  sudo_user: "{{ rbenv_user }}"
+  with_flattened:
+  - rbenv_rubies
+  - "{{ rbenv_default }}"
+
+- name: Check default ruby
+  shell: '~/.rbenv/bin/rbenv version | grep -oE "^[^ ]+"'
+  changed_when: no
+  register: rbenv_current_version
+  sudo: yes
+  sudo_user: "{{ rbenv_user }}"
+
+- name: Set default ruby
+  shell: "~/.rbenv/bin/rbenv global {{ ruby_version }}"
+  sudo: yes
+  sudo_user: "{{ rbenv_user }}"
+  when: rbenv_current_version.stdout != ruby_version
+
+- name: Check for Bundler
+  shell: '~/.rbenv/bin/rbenv exec bundle'
+  failed_when: no
+  changed_when: no
+  register: rbenv_bundle_available
+  sudo: yes
+  sudo_user: "{{ rbenv_user }}"
+
+- name: Install Bundler
+  shell: "~/.rbenv/shims/gem install bundler"
+  sudo: yes
+  sudo_user: "{{ rbenv_user }}"
+  when: rbenv_bundle_available.rc != 0 and rbenv_bundle_available.rc != 10
+
+- name: facts
+  set_fact:
+    RUBY_PREFIX: '/home/{{ rbenv_user }}/.rbenv/bin/rbenv exec '
+    RUBY_BIN: '/home/{{ rbenv_user }}/.rbenv/shims/ruby'

--- a/ruby/rbenv/vars/Debian.yml
+++ b/ruby/rbenv/vars/Debian.yml
@@ -1,0 +1,20 @@
+rbenv_package_names:
+  - curl
+  - bison
+  - build-essential # allow building native gems
+  - zlib1g-dev
+  - libssl-dev
+  - libreadline6-dev
+  - libxml2-dev
+  - git-core
+  - libsqlite3-dev # build native sqlite3 driver
+  - nodejs # precompile assets
+  - autoconf
+  - libyaml-dev
+  - libncurses5-dev
+  - libffi-dev
+  - libgdbm3
+  - libgdbm-dev
+
+# only needed for ruby 2.1.1
+rbenv_ruby_configure_opts: 'RUBY_CONFIGURE_OPTS=--with-readline-dir="/lib/{{ ansible_architecture }}-linux-gnu/libreadline.so.6"'

--- a/ruby/rbenv/vars/RedHat.yml
+++ b/ruby/rbenv/vars/RedHat.yml
@@ -1,0 +1,23 @@
+rbenv_package_names:
+  - curl
+  - bison
+  - make
+  - gcc # - build-essential # allow building native gems
+  # - gcc-c++  # ? - part of debians build-essential
+  - zlib-devel
+  - openssl-devel
+  - readline-devel
+  - libxml2-devel
+  - git
+  - libyaml-devel
+  - libffi-devel
+  - gdbm-devel
+  - ncurses-devel
+  - sqlite-devel # build native sqlite3 driver
+  - nodejs # precompile assets - requires EPEL
+
+# requires a seperate task that's run before any that installs EPEL packages
+rbenv_epel_repo: epel-release
+
+# only needed for rubies 2.1.0 and 2.1.1 on Ubuntu:
+# rbenv_ruby_configure_opts: 'RUBY_CONFIGURE_OPTS=--with-readline-dir="/usr/lib64/libreadline.so"'


### PR DESCRIPTION
I have tested this role *standalone* with Ruby versions 2.1.0..2.2.1 on Ubuntu 12.04 i386, Ubuntu 14.04 x86_64, and CentOS 7.  

The only adaption that I needed to make to existing code to make it work with the ansible-rails-example ("simple"-branch) was to replace the `/bin/sh -lc ...` in the rails/tasks/bundle-role with the **RUBY_PREFIX**. I have also tested that this change doesn't break the harmony with the rvm-role (again "simple"-branch only). I could have solved this otherwise but this way seems to be a much cleaner approach than relying on that things that should happen when a user logs in happen when no user logs in (what the `-l`-option of the shells tries to ensure).

I hope you don't hate too much that my editor removes space on line endings. You can add `?w=1` to the Github urls to ignore the respective lines like [this](?w=1). I could change my editors setting to avoid this in future.

Before I forget to mention it: I felt a great relief to finally get rid of RVM when I began to use rbenv...