### PR TITLE
Added rails app base path to the list of the created folders, so that…

### DIFF
--- a/rails/folders/vars/main.yml
+++ b/rails/folders/vars/main.yml
@@ -1,5 +1,6 @@
 ---
 rails_create_folders:
+- '{{ rails_app_base_path }}'
 - '{{ rails_app_releases_path }}'
 - '{{ rails_app_shared_path }}/config'
 - '{{ rails_app_shared_path }}/bin'


### PR DESCRIPTION
… it receives same owner/group as the others.

the base path wouldn't receive the chown/chgrp attributes as the other paths (My provision script is run by root and thus this folder was owned by root and produced errors later on)
