### PR TITLE
News role: database/backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Provisioning:
 
 * **user/profile** store facts to .profile and .bashrc
 * [**postgresql**](https://github.com/dresden-weekly/ansible-rails/tree/develop/postgresql) install a PostgreSQL 9.3 database
+* [**database/backup**](https://github.com/dresden-weekly/ansible-rails/tree/develop/database/backup) Simple rotating SQL dump backups
 * **upstart/userjobs** enables Upstart userjobs
 * [**ruby/rvm**](https://github.com/dresden-weekly/ansible-rails/tree/develop/ruby/rvm) installs a specific Ruby version with rvm
 * [**ruby/rbenv**](https://github.com/dresden-weekly/ansible-rails/tree/develop/ruby/rbenv) installs a specific Ruby version with rbenv

--- a/database/backup/README.md
+++ b/database/backup/README.md
@@ -13,7 +13,7 @@ Simple rotating SQL dump written to specified folder (e.g. /var/backup). At the 
     database_backup_base_dir: '/var/backup'
 ```
 
-This will create the folder if not exists and create daily cronjob (default 4am) which dumps the database to ``/var/backup/somedb_production/TIMESTAMP.sql``. It will also keep the 7 most recent dumps and delete older ones.
+This will create the folder if not exists and create daily cronjob (default 4am) which dumps the database to ``/var/backup/somedb_production/TIMESTAMP.sql.gz``. It will also keep the 7 most recent dumps and delete older ones.
 
 
 ## Supported variables:

--- a/database/backup/README.md
+++ b/database/backup/README.md
@@ -1,0 +1,21 @@
+## Database/Backup
+
+Simple rotating SQL dump written to specified folder (e.g. /var/backup). At the moment PostgreSQL + MySQL supported.
+
+
+## USAGE
+
+```yaml
+  roles:
+  - role: dresden-weekly.Rails/database/backup
+    database_backup_name: '{{app_name}}_{{rails_env}}'
+    database_backup_type: 'postgresql'
+    database_backup_base_dir: '/var/backup'
+```
+
+This will create the folder if not exists and create daily cronjob (default 4am) which dumps the database to ``/var/backup/somedb_production/TIMESTAMP.sql``. It will also keep the 7 most recent dumps and delete older ones.
+
+
+## Supported variables:
+
+See defaults/main.yml

--- a/database/backup/defaults/main.yml
+++ b/database/backup/defaults/main.yml
@@ -1,0 +1,30 @@
+---
+
+# Assuming Rails databse name
+database_backup_name: "{{app_name}}_{{rails_env}}"
+
+# Backup paths
+database_backup_base_dir: "/var/backup/database"
+database_backup_dir: "{{database_backup_base_dir}}/{{database_backup_name}}"
+
+# Keep that number of backups, e.g. last 7 days
+database_backup_keep: 7
+
+# Crontab hour + minute, e.g. 04:00 am
+database_backup_hour: 4
+database_backup_minute: 0
+
+database_backup_crontab_user: "{{app_user}}"
+
+# either postgresql or mysql
+database_backup_type: postgresql
+
+# Pg-dump assuming trust/ident
+database_backup_pg_job: >
+  pg_dump -c {{database_backup_name}} | gzip > {{database_backup_dir}}/`date +\%F:\%T`.sql.gz && cd {{database_backup_dir}} && rm -f `ls -t | awk 'NR>{{database_backup_keep}}'`
+
+# MySQL Settings:
+database_backup_username: "backup"
+database_backup_password: "backup"
+database_backup_mysql_job: >
+  mysqldump -u"{{database_backup_username}}" -p'{{database_backup_password}}' {{database_backup_name}} | gzip > {{database_backup_dir}}/`date +\%F:\%T`.sql.gz && cd {{database_backup_dir}} && rm -f `ls -t | awk 'NR>{{database_backup_keep}}'`

--- a/database/backup/tasks/main.yml
+++ b/database/backup/tasks/main.yml
@@ -4,7 +4,7 @@
     path: "{{database_backup_dir}}"
     state: directory
     recurse: true
-    owner: "{{app_user}}"
+    owner: "{{database_backup_crontab_user}}"
 
 - name: "Database | Backup | PostgreSQL Cronjob"
   cron:

--- a/database/backup/tasks/main.yml
+++ b/database/backup/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+- name: "Database | Backup | Create Backup directory"
+  file:
+    path: "{{database_backup_dir}}"
+    state: directory
+    recurse: true
+    owner: "{{app_user}}"
+
+- name: "Database | Backup | PostgreSQL Cronjob"
+  cron:
+    name: "backup {{database_backup_name}}"
+    hour: "{{database_backup_hour}}"
+    minute: "{{database_backup_minute}}"
+    job: "{{database_backup_pg_job}}"
+    user: "{{database_backup_crontab_user}}"
+  when: database_backup_type == "postgresql"
+
+- name: "Database | Backup | MySQL Cronjob"
+  cron:
+    name: "backup {{database_backup_name}}"
+    hour: "{{database_backup_hour}}"
+    minute: "{{database_backup_minute}}"
+    job: "{{database_backup_mysql_job}}"
+    user: "{{database_backup_crontab_user}}"
+  when: database_backup_type == "mysql"


### PR DESCRIPTION
- simple opionionated sql dumping creating daily snapshots of the given database
- works good enough for most apps with limited data
- the backup host might just rsync the whole folder regularly

Another idea: the backup folder could be in the app folder, alongside repo, current, shared, releases. How do you guys handle backups?

PG works, but I didn't test the MySQL task, yet. Also didn't specify where the MySQL backup user could come from - that must be created before.
