### PR TITLE
Update the git config before creating a new release

### DIFF
--- a/rails/create-release/defaults/main.yml
+++ b/rails/create-release/defaults/main.yml
@@ -6,6 +6,7 @@ rails_release_id_git_branch: "{{ git_branch }}"
 
 # git repository where rails app taken from
 rails_app_git_repo: "{{ git_url }}"
+rails_app_git_remote: "origin"
 rails_app_git_branch: "{{ git_branch }}"
 
 # path where the repository goes

--- a/rails/create-release/tasks/git.yml
+++ b/rails/create-release/tasks/git.yml
@@ -1,8 +1,15 @@
 ---
+- name: Update repo URL (Ansible 1.8.2 fix)
+  shell: >
+    git remote set-url {{ rails_app_git_remote }} {{ rails_app_git_repo }}
+  args:
+    chdir: "{{ rails_app_repo_path }}"
+
 - name: Ensure git mirror repo is up to date
   git:
     repo: "{{ rails_app_git_repo }}"
     dest: "{{ rails_app_repo_path }}"
+    remote: "{{ rails_app_git_remote }}"
     bare: yes
     version: "{{ rails_app_git_branch }}"
     update: yes


### PR DESCRIPTION
Update the repo URL in the git config before `Ensure git mirror repo is up to date`is executed. If this is not done, a git config with wrong URL will break this task. The remote can now also be specified with `rails_app_git_remote`.
