### PR TITLE
New standard package for Ruby 2.2.3

### DIFF
--- a/ruby/rvm/vars/main.yml
+++ b/ruby/rvm/vars/main.yml
@@ -8,4 +8,5 @@ rvm_packages:
 - libssl-dev
 - libreadline6-dev
 - libxml2-dev
+- libgmp3-dev
 - git-core


### PR DESCRIPTION
I've had some problems after installing Ruby 2.2.3 on a 14.04 - the json gem could not be installed;

A new dependency is required, which i've added.

Reference: https://github.com/flori/json/issues/253
