### PR TITLE
File provisioning: moved from simple copy to yaml based format

### DIFF
--- a/rails/create-release/README.md
+++ b/rails/create-release/README.md
@@ -1,0 +1,25 @@
+## Create release
+
+
+
+### Provide shared files
+
+Files like ``database.yml``, ``secrets.yml`` and Rails ``Rails.application.config_for(:somefile)`` yaml files can be provided by this role.
+
+```yaml
+rails_provisioned_files:
+  - file: config/database.yml
+    yaml:
+      production:
+        adapter: postgresql
+        database: '{{rails_database_name}}'
+        encoding: UTF8
+        pool: 30
+  - file: config/database.yml
+    yaml:
+      production:
+        secret_key_base: '...'
+        twitter_api_key: '...'
+```
+
+Those file will be placed relativ to the shared folders and symlinked into the release/current folders.

--- a/rails/create-release/defaults/main.yml
+++ b/rails/create-release/defaults/main.yml
@@ -46,7 +46,7 @@ rails_shared_files: []
 
 rails_provisioned_files: []
 # - file: config/database.yml
-#   content: |
+#   yaml:
 #     production:
 #       adapter: postgresql
 #       database: '{{rails_database_name}}'

--- a/rails/create-release/tasks/main.yml
+++ b/rails/create-release/tasks/main.yml
@@ -23,10 +23,10 @@
   - rails_deploy_custom_create_folders
 
 
-- name: Provide Rails configuration files
-  copy:
+- name: Provide Rails yaml configuration files
+  template:
+    src: 'config.yml.jinja2'
     dest: "{{ RAILS_APP_SHARED_PATH }}/{{item.file}}"
-    content: '{{item.content}}'
     owner: '{{app_user}}'
     mode: '0600'
   with_items: "{{rails_provisioned_files}}"

--- a/rails/create-release/templates/config.yml.jinja2
+++ b/rails/create-release/templates/config.yml.jinja2
@@ -1,0 +1,3 @@
+---
+# {{ ansible_managed }}
+{{ item.yaml | to_nice_yaml  }}


### PR DESCRIPTION
The approach in #9 doesn't work with yaml-strings with special chars.
- Using the copy, the provided yaml must not contain non-latin1 chars as
  ansible will convert that string somewhere to latin1. This is
  incompatible with YAML and will result in errors when the provided
  files contain specialchars
- Added some documentation in README
- With template -> to_yaml approach it is even more clear - files now contain ansible_managed line, too.
- renamed `content` to `yaml` - Maybe later, other strategies (like local lookup + copy) could be added.
