### PR TITLE
Nginx-Passenger: Improved default site

### DIFF
--- a/nginx/passenger/templates/site.conf.j2
+++ b/nginx/passenger/templates/site.conf.j2
@@ -23,6 +23,7 @@ server {
     expires 21d;
     add_header Pragma public;
     add_header Cache-Control "public, must-revalidate, proxy-revalidate";
+    gzip on;
   }
 
   location ~ ^/(system|uploads)/ {
@@ -34,7 +35,15 @@ server {
 
   # omniauth require https
   location /auth {
-    if ( $https != "on") {
+    # omniauth require https
+    if ($scheme = "http" ) {
+      set $test A;
+    }
+    if ($http_x_forwarded_proto != "https") {
+      set $test "${test}B";
+    }
+    # nginx hack to use multiple conditions
+    if ($test = "AB") {
       rewrite ^ https://$http_host$request_uri? permanent;
     }
     passenger_enabled on;


### PR DESCRIPTION
- gzip also enabled for /assets
- https check for "/auth" (Omniauth) checks also for https forwarded proto, in case
  nginx sits behind proxy  -> Motivation, most Omniauth providers (Twitter, FB, ..) allow only one callback url, so redirect to one canonical makes sense in this case - otherwise ugly exceptions

Hrfilter.de fahrrad-filter.de and another private app are now completly build by Ansible-Rails and running \o/
