### PR TITLE
New role(s) sidekiq worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Provisioning:
 * **ruby/mysql** support for mysql client gems
 * **rails/create-folders** prepares a folder for Rails releases
 * [**rails/logrotate**](https://github.com/dresden-weekly/ansible-rails/tree/develop/rails/logrotate) create logrotate configuration for Rails logs
+* [**rails/jobs/sidekiq**](https://github.com/dresden-weekly/ansible-rails/tree/develop/rails/jobs/sidekiq) manage/restart sidekiq as a upstart job
 * [**nginx/server**](https://github.com/dresden-weekly/ansible-rails/tree/develop/nginx/server) install nginx webserver
 * **nginx/passenger** install nginx webserver
 * [**nginx/puma**](https://github.com/dresden-weekly/ansible-rails/tree/develop/nginx/puma) prepare nginx for puma appserver
@@ -46,6 +47,7 @@ Deployment:
 * **rails/create-release** create a new release from a git repo
 * **rails/use-vagrant** create the vagrant release from a vagrant share
 * **rails/tasks/bundle** install all bundles gems
+* **rails/jobs/sidekiq/restart** see Sidekiq role
 * **rails/tasks/migrate-database** run Rails database migrations
 * **rails/tasks/compile-assets** create the precompiled assets
 * [**rails/publish-assets**](https://github.com/dresden-weekly/ansible-rails/tree/develop/rails/publish-assets) transfer compiled assets from app- to web-servers

--- a/rails/jobs/sidekiq/README.md
+++ b/rails/jobs/sidekiq/README.md
@@ -1,0 +1,57 @@
+## Sidekiq
+
+This role creates a sidekiq worker that is managed via Upstart.
+
+It requires:
+
+* Userjobs Role from Ansible-Rails
+* Some installed and running Redis (not provided by Ansible-Rails) respectively given redis_url reachable
+
+It will create a upstart-job in ``~/.init/APP_NAME.conf``
+
+Variables:
+
+```yaml
+sidekiq_upstart_user: '{{app_user}}'
+sidekiq_job_name: '{{app_name}}'
+sidekiq_upstart_conf: '/home/{{sidekiq_upstart_user}}/.init/{{sidekiq_job_name}}.conf'
+sidekiq_worker_index: 0
+sidekiq_rails_env: '{{rails_env}}'
+sidekiq_log_file: '{{ RAILS_APP_SHARED_PATH }}/log/sidekiq.log'
+sidekiq_config_file: '{{ RAILS_APP_SHARED_PATH }}/config/sidekiq.yml'
+sidekiq_concurrency: 10
+sidekiq_configuration_redis_url: 'redis://localhost:6379/0'
+sidekiq_configuration_verbose: true
+sidekiq_configuration_queues:
+  - [important, 10]
+  - [default, 2]
+  - [low, 1]
+```
+
+## Usage:
+
+1. Server provisioning
+
+creates the job file
+
+After the userjob / redis:
+
+```yaml
+  - role: dresden-weekly.Rails/upstart/userjobs
+    users:
+      - "{{app_user}}"
+  - role: dresden-weekly.Rails/rails/jobs/sidekiq
+    sidekiq_configuration_concurrency: 5
+```
+
+2. (Graceful) restart on deploy
+
+Somewhere at the beginning of your deployment:
+
+```yaml
+  - role: dresden-weekly.rails/rails/jobs/sidekiq/restart
+```
+
+This will trigger a graceful shutdown. Sidekiq won't take any new jobs from this point.
+At the end of the deployment a complete restart with service handlers is executed.
+

--- a/rails/jobs/sidekiq/README.md
+++ b/rails/jobs/sidekiq/README.md
@@ -44,6 +44,15 @@ After the userjob / redis:
     sidekiq_configuration_concurrency: 5
 ```
 
+Sidekiq needs Redis to work. Either set the ``sidekiq_configuration_redis_url``
+to another host or install redis on the same node using another Galaxy role,
+e.g. [geerlingguy.redis](https://github.com/geerlingguy/ansible-role-redis).
+
+```yaml
+roles:
+  - role: geerlingguy.redis
+```
+
 2. (Graceful) restart on deploy
 
 Somewhere at the beginning of your deployment:

--- a/rails/jobs/sidekiq/README.md
+++ b/rails/jobs/sidekiq/README.md
@@ -30,7 +30,7 @@ sidekiq_configuration_queues:
 
 ## Usage:
 
-1. Server provisioning
+### 1. Server provisioning
 
 creates the job file
 
@@ -53,7 +53,7 @@ roles:
   - role: geerlingguy.redis
 ```
 
-2. (Graceful) restart on deploy
+### 2. (Graceful) restart on deploy
 
 Somewhere at the beginning of your deployment:
 

--- a/rails/jobs/sidekiq/defaults/main.yml
+++ b/rails/jobs/sidekiq/defaults/main.yml
@@ -1,0 +1,15 @@
+sidekiq_upstart_user: '{{app_user}}'
+sidekiq_job_name: '{{app_name}}'
+sidekiq_upstart_conf: '/home/{{sidekiq_upstart_user}}/.init/{{sidekiq_job_name}}.conf'
+sidekiq_worker_index: 0
+sidekiq_rails_env: '{{rails_env}}'
+sidekiq_log_file: '{{ RAILS_APP_SHARED_PATH }}/log/sidekiq.log'
+sidekiq_config_file: '{{ RAILS_APP_SHARED_PATH }}/config/sidekiq.yml'
+sidekiq_concurrency: 25
+sidekiq_configuration_redis_url: 'redis://localhost:6379/0'
+sidekiq_configuration_verbose: true
+sidekiq_configuration_queues:
+  - [important, 10]
+  - [default, 2]
+  - [low, 1]
+

--- a/rails/jobs/sidekiq/restart/defaults/main.yml
+++ b/rails/jobs/sidekiq/restart/defaults/main.yml
@@ -1,0 +1,1 @@
+sidekiq_job_name: '{{app_name}}'

--- a/rails/jobs/sidekiq/restart/handlers/main.yml
+++ b/rails/jobs/sidekiq/restart/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: restart sidekiq
+  shell: "{{ profile }}'restart {{sidekiq_job_name}} || start {{sidekiq_job_name}}'"

--- a/rails/jobs/sidekiq/restart/tasks/main.yml
+++ b/rails/jobs/sidekiq/restart/tasks/main.yml
@@ -1,0 +1,4 @@
+- name: Tell sidekiq to not accept new work
+  shell: "{{ profile }}'reload {{sidekiq_job_name}}'"
+  ignore_errors: true
+  notify: restart sidekiq

--- a/rails/jobs/sidekiq/tasks/main.yml
+++ b/rails/jobs/sidekiq/tasks/main.yml
@@ -1,0 +1,14 @@
+- name: sidekiq upstart script
+  template:
+    src: 'sidekiq.conf.j2'
+    dest: '{{ sidekiq_upstart_conf }}'
+  sudo: yes
+  sudo_user: "{{ sidekiq_upstart_user }}"
+
+- name: sidekiq config
+  template:
+    src: 'sidekiq.yml.j2'
+    dest: '{{sidekiq_config_file}}'
+  sudo: yes
+  sudo_user: "{{ sidekiq_upstart_user }}"
+

--- a/rails/jobs/sidekiq/templates/sidekiq.conf.j2
+++ b/rails/jobs/sidekiq/templates/sidekiq.conf.j2
@@ -1,0 +1,35 @@
+# /etc/init/sidekiq.conf - Sidekiq config
+# {{ansible_managed}}
+
+description "Sidekiq Background {{ app_name }}"
+stop on runlevel [06]
+respawn
+respawn limit 3 30
+console log
+normal exit 0 TERM
+reload signal USR1
+instance {{sidekiq_worker_index}}
+
+script
+exec /bin/bash <<'EOT'
+  export HOME="$(eval echo ~$(id -un))"
+  source $HOME/.profile
+  if [ -d "$HOME/.rbenv/bin" ]; then
+    export PATH="$HOME/.rbenv/bin:$HOME/.rbenv/shims:$PATH"
+  elif [ -f  /etc/profile.d/rvm.sh ]; then
+    source /etc/profile.d/rvm.sh
+  elif [ -f /usr/local/rvm/scripts/rvm ]; then
+    source /usr/local/rvm/scripts/rvm
+  elif [ -f "$HOME/.rvm/scripts/rvm" ]; then
+    source "$HOME/.rvm/scripts/rvm"
+  elif [ -f /usr/local/share/chruby/chruby.sh ]; then
+    source /usr/local/share/chruby/chruby.sh
+    if [ -f /usr/local/share/chruby/auto.sh ]; then
+      source /usr/local/share/chruby/auto.sh
+    fi
+  fi
+  cd {{RAILS_APP_CURRENT_PATH}}
+  logger -t {{sidekiq_upstart_user}} "Starting sidekiq worker {{app_name}}: $PWD"
+  exec bundle exec sidekiq -i {{sidekiq_worker_index}} -e {{sidekiq_rails_env}} -C {{sidekiq_config_file}} -L {{sidekiq_log_file}}
+EOT
+end script

--- a/rails/jobs/sidekiq/templates/sidekiq.yml.j2
+++ b/rails/jobs/sidekiq/templates/sidekiq.yml.j2
@@ -1,0 +1,7 @@
+---
+# {{ ansible_managed }}
+:verbose: {{ sidekiq_configuration_verbose }}
+:url: '{{sidekiq_configuration_redis_url}}'
+:concurrency: {{sidekiq_configuration_concurrency}}
+:queues:
+{{sidekiq_configuration_queues | to_nice_yaml}}


### PR DESCRIPTION
- requires userjobs role as it will create a upstart job for sidekiq
- restart script will reload the worker (result in sidekiq stop accepting new jobs) + restart the worker as a handler at the end of deployment
  Redis is hard requirement for sidekiq - the user must install it by herself (e.g. https://github.com/geerlingguy/ansible-role-redis)

borrowed strongly from the puma role :)
