### PR TITLE
Passenger: Add option to remove identifing headers from response

### DIFF
--- a/nginx/passenger/defaults/main.yml
+++ b/nginx/passenger/defaults/main.yml
@@ -4,6 +4,9 @@ passenger_main_variables:
   passenger_root: "/usr/lib/ruby/vendor_ruby/phusion_passenger/locations.ini"
   passenger_ruby: "/usr/bin/passenger_free_ruby"
 
+# Remove identifing headers like Passenger + Nginx version
+passenger_cloak_headers: true
+
 # one or more hosts, like
 # app_hosts: 'www.example.com example.com en.example.com de.example.de'
 app_hosts: '{{app_domain}}'

--- a/nginx/passenger/templates/passenger.conf.j2
+++ b/nginx/passenger/templates/passenger.conf.j2
@@ -3,3 +3,10 @@
 {% for key,value in passenger_main_variables.iteritems() %}
 {{key}} {{value}};
 {% endfor %}
+
+{% if passenger_cloak_headers %}
+more_clear_headers 'X-Powered-By';
+more_clear_headers 'X-Request-Id';
+more_clear_headers 'X-Runtime';
+more_set_headers 'Server: nginx';
+{% endif %}


### PR DESCRIPTION
- Headers X-Powered-By, Request-Id, X-Runtime and Nginx versions are removed

Effect:
- reduced response size
- obstruct probing a bit / reduced surface
