### PR TITLE
Feature: Added option to append SetEnv options to the apache/passenger configuration

### DIFF
--- a/apache/passenger/defaults/main.yml
+++ b/apache/passenger/defaults/main.yml
@@ -17,6 +17,7 @@ apache_vhost_addresses:
 apache_vhost_server_name: "{{ site_domain }}"
 apache_vhost_server_aliases: "{{ app_domain_aliases | default([]) }}"
 apache_vhost_document_root: "{{ site_path }}"
+apache_vhost_include_mode: "0600"
 
 apache_site_options: []
 apache_set_env: []

--- a/apache/passenger/defaults/main.yml
+++ b/apache/passenger/defaults/main.yml
@@ -19,6 +19,7 @@ apache_vhost_server_aliases: "{{ app_domain_aliases | default([]) }}"
 apache_vhost_document_root: "{{ site_path }}"
 
 apache_site_options: []
+apache_set_env: []
 
 passenger_min_instances: 1
 passenger_start_url: "http://{{ site_domain }}:{{ site_port }}{{ site_url_path }}"

--- a/apache/passenger/tasks/vhost.yml
+++ b/apache/passenger/tasks/vhost.yml
@@ -15,6 +15,7 @@
   template:
     dest: "{{ apache_vhost_include_path }}/{{ site_name }}.conf"
     src: "include.conf.j2"
+    mode: "{{ apache_vhost_include_mode }}"
   notify:
   - restart apache
 

--- a/apache/passenger/templates/include.conf.j2
+++ b/apache/passenger/templates/include.conf.j2
@@ -10,6 +10,9 @@
 {% for option, value in apache_site_options.iteritems() %}
   {{ option }} {{ value }}
 {% endfor %}
+{% for key, value in apache_set_env.iteritems() %}
+  SetEnv {{ key }} {{ value }}
+{% endfor %}
 </Directory>
 
 {% if passenger_start_url %}


### PR DESCRIPTION
The main reason I implemented this feature is to have an easy way to add environment variables for the application, with this option we can simply add this to the group vars for example:

```
apache_set_env:
  DATABASE_URL: "{{ DATABASE_URL }}"
  SECRET_KEY_BASE: "{{ app_secret_key_base }}"
```

Now these values doesn't have to be saved in the `.profile` file which needs to be sourced before passenger starts the application.
