### PR TITLE
Removed the run once at db migrating

### DIFF
--- a/rails/tasks/migrate-database/tasks/main.yml
+++ b/rails/tasks/migrate-database/tasks/main.yml
@@ -5,7 +5,6 @@
   command: "{{ profile }}'bundle exec rake db:migrate'"
   args:
     chdir: "{{ RAILS_APP_RELEASE_PATH }}"
-  run_once: true
   register: rails_migrate_database_result
   changed_when: "'migrating' in rails_migrate_database_result.stdout"
   until: rails_migrate_database_result.rc == 0


### PR DESCRIPTION
Run once means that if the task is executed for multiple hosts, it would only run on one. Which is not useful for migrating.
