### PR TITLE
Fixed incopatible rack version when trying to use passenger with ruby version < 2.2

### DIFF
--- a/apache/passenger/tasks/gem_install.yml
+++ b/apache/passenger/tasks/gem_install.yml
@@ -7,6 +7,16 @@
     cache_valid_time: 86400
   with_items: "{{ apache_passenger_gem_packages }}"
 
+- name: install compatible rack version
+  command: >
+    {{ RUBY_PREFIX }} gem install rack --version '1.6.4'
+  become: yes
+  become_user: "{{ app_user }}"
+  register: rack_gem_install_result
+  changed_when: >
+    "Successfully installed" in rack_gem_install_result.stdout
+  when: rvm_default | version_compare('2.2', '<')
+
 - name: install gem
   shell: |
     if ! {{ RUBY_PREFIX }} gem list -i {{ item }} --version "{{ apache_passenger_gem_version }}"


### PR DESCRIPTION
The newest rack gem (released just yesterday) requires a ruby version >=2.2.
And passenger defines a dependency > 0 on rack which leads to passenger also requiring a ruby version > 2.2.
