### PR TITLE
Add environment command-line arg to whenever crontab write; update re…

### DIFF
--- a/rails/tasks/whenever/README.md
+++ b/rails/tasks/whenever/README.md
@@ -4,9 +4,16 @@ Updates Crontab of ``app_user`` with crontab. Requires Gem ``whenever`` to be pr
 
 ### Usage:
 
-
 ```yaml
   roles:
     # ...
     - role: dresden-weekly.Rails/rails/tasks/whenever
+```
+
+- If using in any environment other than `production`, be sure to include the `@environment` argument (which comes in via `--set environment={{ rails_env}}` in the task) in your `config/schedule.rb` file, like this:
+
+```
+every 1.day, at: "4:00am" do
+  rake "some_task:thing", environment: @environment
+end
 ```

--- a/rails/tasks/whenever/tasks/main.yml
+++ b/rails/tasks/whenever/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Update cronjobs for app
-  command: "{{ profile }}'bundle exec whenever --update-crontab {{ app_name }}'"
+  command: "{{ profile }}'bundle exec whenever --set environment={{ rails_env}} --update-crontab {{ app_name }}'"
   args:
     chdir: "{{ RAILS_APP_RELEASE_PATH }}"
   register: rails_whenever_result


### PR DESCRIPTION
Allows environments other than `production` to be written to the whenever-generated crontab.