### PR TITLE
Added python3 compatibility

### DIFF
--- a/apache/passenger/templates/include.conf.j2
+++ b/apache/passenger/templates/include.conf.j2
@@ -5,10 +5,10 @@ RailsBaseURI {{ site_url_path }}
 PassengerRuby {{ passenger_ruby }}
 {% endif %}
 PassengerMinInstances {{ passenger_min_instances }}
-{% for option, value in apache_site_options.iteritems() %}
+{% for option, value in apache_site_options.items() | list %}
 {{ option }} {{ value }}
 {% endfor %}
-{% for key, value in apache_set_env.iteritems() %}
+{% for key, value in apache_set_env.items() | list %}
 SetEnv {{ key }} {{ value }}
 {% endfor %}
 

--- a/apache/server/templates/server_config.conf.j2
+++ b/apache/server/templates/server_config.conf.j2
@@ -3,24 +3,24 @@
 ServerName {{ apache_server_name }}
 {% endif %}
 
-{% for option, value in apache_server_options.iteritems() %}
+{% for option, value in apache_server_options.items() | list %}
 {{ option }} {{ value }}
 {% endfor %}
 
 <IfModule mpm_event_module>
-{% for option, value in apache_event_options.iteritems() %}
+{% for option, value in apache_event_options.items() | list %}
   {{ option }} {{ value }}
 {% endfor %}
 </IfModule>
 
 <IfModule mpm_worker_module>
-{% for option, value in apache_worker_options.iteritems() %}
+{% for option, value in apache_worker_options.items() | list %}
   {{ option }} {{ value }}
 {% endfor %}
 </IfModule>
 
 <IfModule mpm_prefork_module>
-{% for option, value in apache_prefork_options.iteritems() %}
+{% for option, value in apache_prefork_options.items() | list %}
   {{ option }} {{ value }}
 {% endfor %}
 </IfModule>

--- a/apache/vhost/templates/vhost.conf.j2
+++ b/apache/vhost/templates/vhost.conf.j2
@@ -7,7 +7,7 @@
 
   DocumentRoot {{ apache_vhost_document_root }}
 
-  {% for option, value in apache_vhost_options.iteritems() %}
+  {% for option, value in apache_vhost_options.items() | list %}
   {{ option }} {{ value }}
   {% endfor %}
 

--- a/nginx/passenger/templates/passenger.conf.j2
+++ b/nginx/passenger/templates/passenger.conf.j2
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 
-{% for key,value in passenger_main_variables.iteritems() %}
+{% for key,value in passenger_main_variables.items() | list %}
 {{key}} {{value}};
 {% endfor %}
 

--- a/nginx/passenger/templates/site.conf.j2
+++ b/nginx/passenger/templates/site.conf.j2
@@ -15,7 +15,7 @@ server {
   client_max_body_size 200M;
   root {{RAILS_APP_CURRENT_PATH}}/public;
 
-  {% for key,value in passenger_variables.iteritems() %}
+  {% for key,value in passenger_variables.items() | list %}
   {{key}} {{value}};
   {% endfor %}
 

--- a/nginx/server/templates/nginx.conf.j2
+++ b/nginx/server/templates/nginx.conf.j2
@@ -5,7 +5,7 @@ pid {{ nginx_pid }};
 worker_processes {{ nginx_worker_processes }};
 
 events {
-{% for k,v in nginx_events.iteritems() %}
+{% for k,v in nginx_events.items() | list %}
   {{ k }} {{ v }};
 {% endfor %}
 }
@@ -17,7 +17,7 @@ http {
   access_log {{ nginx_access_log }};
   error_log {{ nginx_error_log }};
 
-{% for k,v in nginx_http_options.iteritems() %}
+{% for k,v in nginx_http_options.items() | list %}
   {{ k }} {{ v }};
 {% endfor %}
 

--- a/nginx/unicorn/templates/site.conf.j2
+++ b/nginx/unicorn/templates/site.conf.j2
@@ -24,7 +24,7 @@ server {
     proxy_pass http://{{ site_name }};
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-{% for name, value in nginx_app_headers.iteritems() -%}
+{% for name, value in nginx_app_headers.items() | list -%}
     proxy_set_header {{ name }} {{ value }};
 {% endfor -%}
     proxy_redirect off;

--- a/postgresql/templates/postgresql.conf.j2
+++ b/postgresql/templates/postgresql.conf.j2
@@ -21,7 +21,7 @@ listen_addresses = '{{ postgresql_listen | join(',') }}'
 port = {{ postgresql_port }}
 max_connections = {{ postgresql_max_connections }}
 unix_socket_directories = '{{ postgresql_socket_directories | join(',') }}'
-{% for k,v in postgresql_connections.iteritems() %}
+{% for k,v in postgresql_connections.items() | list %}
 {{ k }} = {{ v }}
 {% endfor %}
 
@@ -29,7 +29,7 @@ unix_socket_directories = '{{ postgresql_socket_directories | join(',') }}'
 # RESOURCE USAGE (except WAL)
 #------------------------------------------------------------------------------
 
-{% for k,v in postgresql_resources.iteritems() %}
+{% for k,v in postgresql_resources.items() | list %}
 {{ k }} = {{ v }}
 {% endfor %}
 
@@ -37,7 +37,7 @@ unix_socket_directories = '{{ postgresql_socket_directories | join(',') }}'
 # WRITE AHEAD LOG
 #------------------------------------------------------------------------------
 
-{% for k,v in postgresql_write_ahead_log.iteritems() %}
+{% for k,v in postgresql_write_ahead_log.items() | list %}
 {{ k }} = {{ v }}
 {% endfor %}
 
@@ -45,7 +45,7 @@ unix_socket_directories = '{{ postgresql_socket_directories | join(',') }}'
 # REPLICATION
 #------------------------------------------------------------------------------
 
-{% for k,v in postgresql_replication.iteritems() %}
+{% for k,v in postgresql_replication.items() | list %}
 {{ k }} = {{ v }}
 {% endfor %}
 
@@ -53,7 +53,7 @@ unix_socket_directories = '{{ postgresql_socket_directories | join(',') }}'
 # QUERY TUNING
 #------------------------------------------------------------------------------
 
-{% for k,v in postgresql_query_tuning.iteritems() %}
+{% for k,v in postgresql_query_tuning.items() | list %}
 {{ k }} = {{ v }}
 {% endfor %}
 
@@ -61,7 +61,7 @@ unix_socket_directories = '{{ postgresql_socket_directories | join(',') }}'
 # ERROR REPORTING AND LOGGING
 #------------------------------------------------------------------------------
 
-{% for k,v in postgresql_logging.iteritems() %}
+{% for k,v in postgresql_logging.items() | list %}
 {{ k }} = {{ v }}
 {% endfor %}
 
@@ -69,7 +69,7 @@ unix_socket_directories = '{{ postgresql_socket_directories | join(',') }}'
 # RUNTIME STATISTICS
 #------------------------------------------------------------------------------
 
-{% for k,v in postgresql_runtime_statistics.iteritems() %}
+{% for k,v in postgresql_runtime_statistics.items() | list %}
 {{ k }} = {{ v }}
 {% endfor %}
 
@@ -77,7 +77,7 @@ unix_socket_directories = '{{ postgresql_socket_directories | join(',') }}'
 # AUTOVACUUM PARAMETERS
 #------------------------------------------------------------------------------
 
-{% for k,v in postgresql_autovacuum.iteritems() %}
+{% for k,v in postgresql_autovacuum.items() | list %}
 {{ k }} = {{ v }}
 {% endfor %}
 
@@ -85,7 +85,7 @@ unix_socket_directories = '{{ postgresql_socket_directories | join(',') }}'
 # CLIENT CONNECTION DEFAULTS
 #------------------------------------------------------------------------------
 
-{% for k,v in postgresql_client_connection_defaults.iteritems() %}
+{% for k,v in postgresql_client_connection_defaults.items() | list %}
 {{ k }} = {{ v }}
 {% endfor %}
 
@@ -93,7 +93,7 @@ unix_socket_directories = '{{ postgresql_socket_directories | join(',') }}'
 # LOCK MANAGEMENT
 #------------------------------------------------------------------------------
 
-{% for k,v in postgresql_lock_management.iteritems() %}
+{% for k,v in postgresql_lock_management.items() | list %}
 {{ k }} = {{ v }}
 {% endfor %}
 
@@ -101,6 +101,6 @@ unix_socket_directories = '{{ postgresql_socket_directories | join(',') }}'
 # CUSTOMIZED OPTIONS
 #------------------------------------------------------------------------------
 
-{% for k,v in postgresql_cutomized.iteritems() %}
+{% for k,v in postgresql_cutomized.items() | list %}
 {{ k }} = {{ v }}
 {% endfor %}

--- a/puma/service/templates/puma.rb.j2
+++ b/puma/service/templates/puma.rb.j2
@@ -7,7 +7,7 @@ directory "{{ puma_directory }}"
 rackup "{{ puma_rackup }}"
 pidfile "{{ puma_pidfile }}"
 
-{% for typ,v in puma_binds.iteritems() %}
+{% for typ,v in puma_binds.items() | list %}
 bind "{{ typ }}://{{ v }}"
 {% endfor %}
 


### PR DESCRIPTION
"Jinja2 templates should use dict.keys(), dict.values(), and
dict.items() in order to be compatible with both Python2 and Python3"

http://docs.ansible.com/ansible/latest/playbooks_python_version.html