### PR TITLE
Added role for managing mailroom via Systemd user job

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Provisioning:
 * **rails/create-folders** prepares a folder for Rails releases
 * [**rails/logrotate**](https://github.com/dresden-weekly/ansible-rails/tree/develop/rails/logrotate) create logrotate configuration for Rails logs
 * [**rails/jobs/sidekiq**](https://github.com/dresden-weekly/ansible-rails/tree/develop/rails/jobs/sidekiq) manage/restart sidekiq as a upstart job
+* [**rails/jobs/mailroom**](https://github.com/dresden-weekly/ansible-rails/tree/develop/rails/mailroom/sidekiq) manage/restart Mailroom as an systemd job (Ubuntu 16+) to listen for incoming emails in time
 * [**nginx/server**](https://github.com/dresden-weekly/ansible-rails/tree/develop/nginx/server) install Nginx webserver
 * **nginx/passenger** install Nginx webserver
 * [**nginx/puma**](https://github.com/dresden-weekly/ansible-rails/tree/develop/nginx/puma) prepare nginx for Puma appserver

--- a/rails/jobs/mailroom/README.md
+++ b/rails/jobs/mailroom/README.md
@@ -1,0 +1,31 @@
+## MailRoom
+
+Enables a systemd service job for the ``mail_room`` exec, that enables your app to listen for incoming emails.
+
+Vars:
+
+```yaml
+mailroom_job_name: "mailroom-{{ app_name }}"
+mailroom_config_file: "{{ RAILS_APP_SHARED_PATH }}/config/mailroom.yml"
+mailroom_user: "{{app_user}}"
+```
+
+## Usage:
+
+### 1. Server provisioning
+
+creates the systemd unit job and enables it
+
+```yaml
+  - role: dresden-weekly.Rails/rails/jobs/mailroom
+```
+
+MailRoom works great in combination with Sidekiq. This Role does not provide a method for creating the mailroom config at the moment. It need to be delivered via other methods (provision files, part of app code)
+
+### 2. Restart on deploy
+
+Maybe not necessary, when you never change the Delivery Settings/Config File or the Sidekiq Worker name that changes for a job
+
+```yaml
+  - role: dresden-weekly.rails/rails/jobs/mailroom/restart
+```

--- a/rails/jobs/mailroom/defaults/main.yml
+++ b/rails/jobs/mailroom/defaults/main.yml
@@ -1,0 +1,3 @@
+mailroom_job_name: "mailroom-{{ app_name }}"
+mailroom_config_file: "{{ RAILS_APP_SHARED_PATH }}/config/mailroom.yml"
+mailroom_user: "{{app_user}}"

--- a/rails/jobs/mailroom/defaults/main.yml
+++ b/rails/jobs/mailroom/defaults/main.yml
@@ -1,3 +1,4 @@
 mailroom_job_name: "mailroom-{{ app_name }}"
 mailroom_config_file: "{{ RAILS_APP_SHARED_PATH }}/config/mailroom.yml"
 mailroom_user: "{{app_user}}"
+mailroom_workdir: "{{RAILS_APP_CURRENT_PATH}}"

--- a/rails/jobs/mailroom/restart/defaults/main.yml
+++ b/rails/jobs/mailroom/restart/defaults/main.yml
@@ -1,0 +1,1 @@
+mailroom_job_name: "mailroom-{{ app_name }}"

--- a/rails/jobs/mailroom/restart/handlers/main.yml
+++ b/rails/jobs/mailroom/restart/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: restart mailroom (systemd)
+  shell: 'sudo -n /bin/systemctl restart {{mailroom_job_name}}'

--- a/rails/jobs/mailroom/restart/tasks/main.yml
+++ b/rails/jobs/mailroom/restart/tasks/main.yml
@@ -1,0 +1,2 @@
+- include: "systemd.yml"
+  when: 'ansible_service_mgr == "systemd"'

--- a/rails/jobs/mailroom/restart/tasks/systemd.yml
+++ b/rails/jobs/mailroom/restart/tasks/systemd.yml
@@ -1,0 +1,8 @@
+# - name: Tell mailroom to not accept new work
+#   shell: 'sudo -n /bin/systemctl kill -s USR1 {{mailroom_job_name}}'
+#   ignore_errors: true
+
+- command: '/bin/true'
+  name: 'Make sure mailroom is started at the end'
+  notify: restart mailroom (systemd)
+

--- a/rails/jobs/mailroom/tasks/main.yml
+++ b/rails/jobs/mailroom/tasks/main.yml
@@ -1,0 +1,2 @@
+- include: "systemd.yml"
+  when: 'ansible_service_mgr == "systemd"'

--- a/rails/jobs/mailroom/tasks/systemd.yml
+++ b/rails/jobs/mailroom/tasks/systemd.yml
@@ -1,0 +1,19 @@
+- name: Create {{mailroom_job_name}}.service for systemd
+  template:
+    src: mailroom.service.j2
+    dest: /lib/systemd/system/{{mailroom_job_name}}.service
+  register: mailroomtpl
+
+- systemd:
+    state: started
+    enabled: true
+    daemon_reload: true
+    name: "{{mailroom_job_name}}"
+  when: mailroomtpl.changed
+  ignore_errors: true
+  name: "Enable/Reload systemd"
+
+- template:
+    src: 'sudoers.j2'
+    dest: '/etc/sudoers.d/{{mailroom_job_name}}'
+  name: "Enable passwordless sudo for job control of {{mailroom_job_name}}"

--- a/rails/jobs/mailroom/templates/mailroom.service.j2
+++ b/rails/jobs/mailroom/templates/mailroom.service.j2
@@ -1,0 +1,38 @@
+# {{ansible_managed}}
+# Template: https://github.com/mperham/mailroom/blob/master/examples/systemd/mailroom.service
+#
+# systemd unit file for CentOS 7, Ubuntu 15.04
+#
+[Unit]
+Description=mailroom {{app_name}}
+# start us only once the network and logging subsystems are available,
+# consider adding redis-server.service if Redis is local and systemd-managed.
+After=syslog.target network.target
+
+# See these pages for lots of options:
+# http://0pointer.de/public/systemd-man/systemd.service.html
+# http://0pointer.de/public/systemd-man/systemd.exec.html
+[Service]
+Type=simple
+WorkingDirectory={{RAILS_APP_CURRENT_PATH}}
+# If you use rbenv:
+# ExecStart=/bin/bash -lc 'bundle exec mail_room'
+# If you use the system's ruby:
+ExecStart=/bin/bash -l -c 'bundle exec mail_room -c {{ mailroom_config_file }}'
+User={{rails_user_name}}
+Group={{rails_user_name}}
+UMask=0002
+
+# if we crash, restart
+RestartSec=1
+Restart=on-failure
+
+# output goes to /var/log/syslog
+StandardOutput=syslog
+StandardError=syslog
+
+# This will default to "bundler" if we don't specify it
+SyslogIdentifier=mailroom {{app_name}}
+
+[Install]
+WantedBy=multi-user.target

--- a/rails/jobs/mailroom/templates/mailroom.service.j2
+++ b/rails/jobs/mailroom/templates/mailroom.service.j2
@@ -4,7 +4,7 @@
 # systemd unit file for CentOS 7, Ubuntu 15.04
 #
 [Unit]
-Description=mailroom {{app_name}}
+Description=mailroom {{mailroom_user}}
 # start us only once the network and logging subsystems are available,
 # consider adding redis-server.service if Redis is local and systemd-managed.
 After=syslog.target network.target
@@ -14,13 +14,13 @@ After=syslog.target network.target
 # http://0pointer.de/public/systemd-man/systemd.exec.html
 [Service]
 Type=simple
-WorkingDirectory={{RAILS_APP_CURRENT_PATH}}
+WorkingDirectory={{mailroom_workdir}}
 # If you use rbenv:
 # ExecStart=/bin/bash -lc 'bundle exec mail_room'
 # If you use the system's ruby:
 ExecStart=/bin/bash -l -c 'bundle exec mail_room -c {{ mailroom_config_file }}'
-User={{rails_user_name}}
-Group={{rails_user_name}}
+User={{mailroom_user}}
+Group={{mailroom_user}}
 UMask=0002
 
 # if we crash, restart
@@ -32,7 +32,7 @@ StandardOutput=syslog
 StandardError=syslog
 
 # This will default to "bundler" if we don't specify it
-SyslogIdentifier=mailroom {{app_name}}
+SyslogIdentifier=mailroom {{mailroom_user}}
 
 [Install]
 WantedBy=multi-user.target

--- a/rails/jobs/mailroom/templates/sudoers.j2
+++ b/rails/jobs/mailroom/templates/sudoers.j2
@@ -1,0 +1,5 @@
+# {{ansible_managed}}
+%{{mailroom_user}} ALL= NOPASSWD: /bin/systemctl start {{mailroom_job_name}}
+%{{mailroom_user}} ALL= NOPASSWD: /bin/systemctl stop {{mailroom_job_name}}
+%{{mailroom_user}} ALL= NOPASSWD: /bin/systemctl restart {{mailroom_job_name}}
+%{{mailroom_user}} ALL= NOPASSWD: /bin/systemctl status {{mailroom_job_name}}


### PR DESCRIPTION
We are using mail_room to enable on of our apps to receive incoming mails in "realtime". 
MailRoom is launched as a systemd job and connects to the IMAP account given in it's config.
In the recommended config, mailRoom puts that jobs into a "sidekiq" Redis queue. Another way would be to call a webhook (determined by the config file mailroom_config_file which is not managed by this role).

* Allow app user to manage job (start/stop/restart) via sudo
* Tested with Ubuntu 16.04