### PR TITLE
Add Webpack + Yarn usage by simple new flag `rails_webpacker`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Provisioning:
 * [**apache/vhost**](https://github.com/dresden-weekly/ansible-rails/tree/develop/apache/vhost) add an Apache vhost configuration
 * **firewalld** configure firewalld (for CentOS)
 * **selinux** currently only enable/disable selinux on CentOS
+* [**yarn**](https://github.com/dresden-weekly/ansible-rails/tree/develop/yarn) Installs nodejs + yarn (default nodejs-6.x)
 
 Deployment:
 

--- a/rails/create-release/README.md
+++ b/rails/create-release/README.md
@@ -23,3 +23,21 @@ rails_provisioned_files:
 ```
 
 Those file will be placed relativ to the shared folders and symlinked into the release/current folders.
+
+
+### Webpacker integration
+
+Just set this variable in your provisioning/deployment:
+
+```
+rails_webpacker: yes
+```
+
+This will:
+
+1. (this role) Export these files from git in addition to the defaults: yarn.lock package.json .babelrc .postcssrc.yml
+2. (this role) Keep/Symlink public/packs and node_modules between deployments
+3. (asset precompilation) ``rake yarn:install`` is run by ``rails assets:precompile`` (from +5.1), if a bin/yarn binstub is provided. **NOTE** without that binstub no node_modules are installed! Make sure to add it with ``rails app:update:bin`` and commit to your app repo.
+
+You might also want to include the [**yarn**](https://github.com/dresden-weekly/ansible-rails/tree/develop/yarn) Installs nodejs + yarn (default nodejs-6.x) role in your provisioning before, to install required nodejs + yarn.
+

--- a/rails/create-release/defaults/main.yml
+++ b/rails/create-release/defaults/main.yml
@@ -44,6 +44,18 @@ rails_deploy_custom_shared_folders: [] # custom folders that are shared between 
 
 rails_deploy_custom_create_folders: [] # custom folders that are created for each release
 
+# Webpacker / yarn default settings
+rails_webpacker: no
+rails_deploy_webpacker_archive:
+- yarn.lock
+- package.json
+- .babelrc
+- .postcssrc.yml
+
+rails_deploy_webpacker_pack_dir: public/packs
+rails_deploy_custom_shared_webpacker_folders: ['{{rails_deploy_webpacker_pack_dir}}', 'node_modules']
+
+
 # Link files
 rails_shared_files: []
 # - db/production.sqlite3

--- a/rails/create-release/tasks/git.yml
+++ b/rails/create-release/tasks/git.yml
@@ -17,6 +17,7 @@
   shell: >
     git archive --format=tar --prefix={{ RAILS_APP_RELEASE_ID }}/ {{ rails_app_git_branch }}
     {{ rails_deploy_archive | join(' ') }}
+    {{ rails_deploy_webpacker_archive | join(' ') if rails_webpacker else "" }}
     {{ rails_deploy_custom_archive | join(' ') }}
     | (cd {{ RAILS_APP_RELEASES_PATH }} && tar -xf -)
   args:

--- a/rails/create-release/tasks/shared_folders.yml
+++ b/rails/create-release/tasks/shared_folders.yml
@@ -6,6 +6,7 @@
   with_flattened:
   - "{{ rails_deploy_shared_folders }}"
   - "{{ rails_deploy_custom_shared_folders }}"
+  - "{{ rails_deploy_custom_shared_webpacker_folders if rails_webpacker else [] }}"
 
 - name: Link shared folders
   file:
@@ -16,6 +17,7 @@
   with_flattened:
   - "{{ rails_deploy_shared_folders }}"
   - "{{ rails_deploy_custom_shared_folders }}"
+  - "{{ rails_deploy_custom_shared_webpacker_folders if rails_webpacker else [] }}"
 
 - name: Link shared files
   file:

--- a/yarn/README.md
+++ b/yarn/README.md
@@ -1,0 +1,13 @@
+## Nodejs + Yarn
+
+Intended to run during initial provisioning.
+
+```yaml
+- role: dresden-weekly.rails/yarn
+  nodejs_version: 'nodejs-v6x'
+```
+
+Installs Yarn + Nodejs via ppa/apt repository
+
+**NOTE**: If you want to use yarn, you also might want to enable yarn:install step during deployment, see [**rails/create-release**](https://github.com/dresden-weekly/ansible-rails/tree/develop/rails/create-release)
+

--- a/yarn/defaults/main.yml
+++ b/yarn/defaults/main.yml
@@ -1,0 +1,29 @@
+nodejs_version: 'nodejs-v6x'
+
+nodejs_install:
+- build-essential
+
+nodejs_version_map:
+  nodejs-v7x: '7.x'
+  nodejs-v6x: '6.x'
+  nodejs-v5x: '5.x'
+  nodejs-v4x: '4.x'
+  nodejs-v012: '0.12'
+  nodejs-v010: '0.10'
+  iojs-v3x: 'iojs_3.x'
+  iojs-v2x: 'iojs_2.x'
+  iojs-v1x: 'iojs_1.x'
+
+nodejs_dependencies:
+  - curl
+
+yarn_repositories:
+- type: deb
+  url: 'https://dl.yarnpkg.com/debian/ stable'
+  component: main
+
+yarn_dependencies_pre:
+- apt-transport-https
+
+yarn_dependencies:
+- yarn

--- a/yarn/tasks/main.yml
+++ b/yarn/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- include: 'nodejs.yml'
+- include: 'yarn.yml'

--- a/yarn/tasks/nodejs.yml
+++ b/yarn/tasks/nodejs.yml
@@ -1,0 +1,22 @@
+- name: install dependencies
+  apt:
+    name: "{{ item }}"
+    update_cache: true
+    cache_valid_time: 3600
+  with_items: "{{ nodejs_dependencies }}"
+
+- name: install additional
+  apt:
+    name: "{{ item }}"
+  with_items: "{{ nodejs_install }}"
+
+- name: add repository and install its signing key
+  shell: curl -sL https://deb.nodesource.com/setup_{{ nodejs_version_map[nodejs_version] }} | bash -
+  args:
+    creates: /etc/apt/sources.list.d/nodesource.list
+
+- name: install nodejs
+  apt:
+    name: "{{ 'nodejs' if 'nodejs' in nodejs_version else 'iojs' }}"
+    update_cache: true
+    state: latest

--- a/yarn/tasks/yarn.yml
+++ b/yarn/tasks/yarn.yml
@@ -1,0 +1,12 @@
+---
+- name: Configure the Yarn APT key
+  apt_key: url=https://dl.yarnpkg.com/debian/pubkey.gpg
+
+- name: Add Yarn repository
+  apt_repository:
+    repo: 'deb https://dl.yarnpkg.com/debian/ stable main'
+    state: present
+
+- name: Install Yarn
+  apt: pkg=yarn state=present
+


### PR DESCRIPTION
With Rails 5.1, now webpacker and yarn are first class citizens. To accommodate, I propose those changes:

- New Task "yarn", which installs both nodejs + yarn (inspired by other   roles), to be run at provision stag (tersmitten.nodejs + Oefenweb.yarn as template, but modified to be made simpler)
- create-release: important yarn files are git-exported, node_modules + packs folder symlinked at deploy stage
- yarn install is taken care of by rake asset:precompile in Rails 5.1 (https://github.com/rails/rails/blob/master/railties/lib/rails/tasks/yarn.rake). IMPORTANT: One has to create a binstub bin/yarn (rails app:update:bin) before, otherwise nothing will happen.

@arBmind any objections or remarks?