### PR TITLE
Reliably enable and start nginx on systemdified Debianoids

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,10 @@ script:
   - 'sudo docker run --ulimit nofile=1024 --detach --volume="${PWD}":"/etc/ansible/roles/dresden-weekly.Rails":ro ${run_opts} ${distribution}-${version}:ansible "${init}" > "${container_id}"'
 
   # Ansible syntax check.
-  - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/dresden-weekly.Rails/tests/itedd.yml --syntax-check'
+  - 'sudo docker exec "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/dresden-weekly.Rails/tests/itedd.yml --syntax-check'
 
   # Test role.
-  - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/dresden-weekly.Rails/tests/itedd.yml'
+  - 'sudo docker exec "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/dresden-weekly.Rails/tests/itedd.yml'
 
   # Test role idempotence.
   - >-

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
 script:
   - container_id=$(mktemp)
     # Run container in detached state
-  - 'sudo docker run --detach --volume="${PWD}":"/etc/ansible/roles/dresden-weekly.Rails":ro ${run_opts} ${distribution}-${version}:ansible "${init}" > "${container_id}"'
+  - 'sudo docker run --ulimit nofile=1024 --detach --volume="${PWD}":"/etc/ansible/roles/dresden-weekly.Rails":ro ${run_opts} ${distribution}-${version}:ansible "${init}" > "${container_id}"'
 
   # Ansible syntax check.
   - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/dresden-weekly.Rails/tests/itedd.yml --syntax-check'

--- a/nginx/server/tasks/Debian.yml
+++ b/nginx/server/tasks/Debian.yml
@@ -1,12 +1,19 @@
 ---
-- name: Repo
+- name: Debian | Repo
   apt_repository:
     repo: "{{ nginx_apt_repo }}"
 
-- name: Packages
+- name: Debian | Packages
   apt:
     name: "{{ item }}"
     update_cache: yes
     state: latest
     cache_valid_time: 86400
   with_items: "{{ nginx_package_names }}"
+
+- name: Debian | Enable nginx
+  service:
+    name: "{{ nginx_service_name }}"
+    enabled: yes
+  notify:
+  - restart nginx


### PR DESCRIPTION
I observed a strange behaviour on Ubuntu 16.04, where nginx isn't automatically enabled/started after installation (like it should, according to systemd vendor preset and traditional Debian behaviour).

Explicitly enabling and restarting the service here shouldn't do harm and ensures that the webserver is actually running.