### PR TITLE
Fix Travis / Docker Test Suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,10 @@ script:
   - 'sudo docker run --ulimit nofile=1024 --detach --volume="${PWD}":"/etc/ansible/roles/dresden-weekly.Rails":ro ${run_opts} ${distribution}-${version}:ansible "${init}" > "${container_id}"'
 
   # Ansible syntax check.
-  - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/dresden-weekly.Rails/tests/itedd.yml --syntax-check'
+  - 'sudo docker exec "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/dresden-weekly.Rails/tests/itedd.yml --syntax-check'
 
   # Test role.
-  - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/dresden-weekly.Rails/tests/itedd.yml'
+  - 'sudo docker exec "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/dresden-weekly.Rails/tests/itedd.yml'
 
   # Test role idempotence.
   - >-

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
 script:
   - container_id=$(mktemp)
     # Run container in detached state
-  - 'sudo docker run --detach --volume="${PWD}":"/etc/ansible/roles/dresden-weekly.Rails":ro ${run_opts} ${distribution}-${version}:ansible "${init}" > "${container_id}"'
+  - 'sudo docker run --ulimit nofile=1024 --detach --volume="${PWD}":"/etc/ansible/roles/dresden-weekly.Rails":ro ${run_opts} ${distribution}-${version}:ansible "${init}" > "${container_id}"'
 
   # Ansible syntax check.
   - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/dresden-weekly.Rails/tests/itedd.yml --syntax-check'


### PR DESCRIPTION
Apparently Docker sets a higher ulimit -n than an usual Linux environment.
This leads an apt subprocess to believe it's a good idea to process 1 million files at ones, which makes the setup steps grinding slow.