### PR TITLE
Support for Ubuntu 16.04 test environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ env:
   #   version: 7
   #   init: /usr/lib/systemd/systemd
   #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  # - distribution: ubuntu
-  #   version: 16.04
-  #   init: /sbin/init
-  #   run_opts: ""
+  - distribution: ubuntu
+    version: 16.04
+    init: /sbin/init
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro --volume=/sys/fs/cgroup/systemd:/sys/fs/cgroup/systemd:rw"
   - distribution: ubuntu-upstart
     version: 14.04
     init: /sbin/init

--- a/postgresql/defaults/main.yml
+++ b/postgresql/defaults/main.yml
@@ -3,12 +3,12 @@
 postgresql_version: "9.3"
 
 # table locale and character encoding
-postgresql_locale: "en_US"
+postgresql_locale: "C"
 postgresql_encoding: "UTF-8"
 
 # shell locale and character encoding
 postgresql_shell_locale: "{{ postgresql_locale }}"
-postgresql_shell_encoding: "{{ postgresql_encoding | replace('-', '') | lower }}"
+postgresql_shell_encoding: "{{ postgresql_encoding }}"
 
 # default application database
 db_user: '' # name of the user (empty means no user is created)

--- a/systemd/usermanager/defaults/main.yml
+++ b/systemd/usermanager/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# list of user names, that use systemd user manager
+users: []

--- a/systemd/usermanager/tasks/Debian.yml
+++ b/systemd/usermanager/tasks/Debian.yml
@@ -1,0 +1,3 @@
+- name: Debian | Install libpam for systemd
+  apt:
+    pkg: libpam-systemd

--- a/systemd/usermanager/tasks/main.yml
+++ b/systemd/usermanager/tasks/main.yml
@@ -1,0 +1,9 @@
+- include_tasks: Debian.yml
+  when: ansible_os_family == "Debian"
+
+
+- name: Enable systemd User Manager
+  systemd:
+    name: user@{{ item }}
+    state: started
+  loop: "{{ users }}"

--- a/systemd/usermanager/tasks/main.yml
+++ b/systemd/usermanager/tasks/main.yml
@@ -7,3 +7,23 @@
     name: user@{{ item }}
     state: started
   loop: "{{ users }}"
+
+
+- command: systemctl status user@deploy
+  register: foo
+  failed_when: false
+- debug: var=foo
+
+- command: ps aux
+  register: psaux
+- debug: var=psaux
+
+
+- name: Check for systemd user session
+  shell: 'ps aux | grep "systemd --user" | grep -v grep'
+  register: bar
+  failed_when: bar.stdout == ""
+
+
+- name: Print out result
+  debug: var=bar

--- a/tests/itedd.yml
+++ b/tests/itedd.yml
@@ -70,6 +70,13 @@
     - role: dresden-weekly.Rails/upstart/userjobs
       users:
       - "{{ app_user }}"
+      when: ansible_service_mgr == "upstart"
+      
+    - role: dresden-weekly.Rails/systemd/usermanager
+      users:
+      - "{{ app_user }}"
+      when: ansible_service_mgr == "systemd"
+
     - dresden-weekly.Rails/webrick/service
     - dresden-weekly.Rails/nginx/server
     - dresden-weekly.Rails/nginx/webrick

--- a/tests/itedd.yml
+++ b/tests/itedd.yml
@@ -47,6 +47,12 @@
         shell: /bin/bash
 
   roles:
+  
+    - role: dresden-weekly.Rails/systemd/usermanager
+      users:
+      - "{{ app_user }}"
+      when: ansible_service_mgr == "systemd"
+      
     - dresden-weekly.Rails/postgresql
 
     - dresden-weekly.Rails/ruby/rvm

--- a/tests/itedd.yml
+++ b/tests/itedd.yml
@@ -41,12 +41,6 @@
     #         pool: 5
 
   pre_tasks:
-    - file:
-        path: '/etc/locale.gen'
-        state: 'absent'
-    - shell: 'locale-gen "en_US.UTF-8"'
-      changed_when: no
-
     - name: Create App User
       user:
         name: "{{ app_user }}"

--- a/webrick/service/tasks/systemd.yml
+++ b/webrick/service/tasks/systemd.yml
@@ -12,6 +12,36 @@
   become: yes
   when: "{{ 'Failed' in systemd_linger_enabled_test.stderr }}"
 
+
+
+- name: ps aux
+  command: "ps aux"
+  register: psaux 
+- debug: var=psaux
+
+
+
+- name: systemctl status
+  command: "systemctl status user@deploy"
+  register: systemctl
+  failed_when: false
+- debug: var=systemctl
+
+- become_user: "{{ webrick_user }}"
+  block:      
+    - name: env
+      command: "env"
+      register: envc 
+    - debug: var=envc
+
+    
+- command: "sudo -iu {{ webrick_user }} env"
+  register: envs
+- debug: var=envs
+
+
+
+
 - become_user: "{{ webrick_user }}"
   block:
     - name: "Systemd | Ensure complete .profile"
@@ -19,6 +49,13 @@
         dest: "~/.profile"
         regexp: "^export XDG_RUNTIME_DIR="
         line: "export XDG_RUNTIME_DIR=/run/user/`id -u`"
+
+- become_user: "{{ webrick_user }}"
+  block:
+    - name: env
+      command: "env"
+      register: envc 
+    - debug: var=envc
 
     - name: Systemd | Ensure the user units folder exists
       file:
@@ -29,6 +66,14 @@
       template:
         dest: "{{ webrick_systemd_unit }}"
         src: systemd.service.j2
+      failed_when: false
+
+    - name: Systemd | Enable unit at boot
+      shell: "/bin/bash -lc -- 'env'"
+      register: envb
+
+    - debug: var=envb
+
 
     - name: Systemd | Enable unit at boot
       shell: "/bin/bash -lc -- 'systemctl --user enable {{ webrick_service_name }}.service'"


### PR DESCRIPTION
Implements #76 

Some relevant changes:
- Don't use en_US.UTF-8 locale for Postgres, C.UTF-8 should be fine for all systems
- Don't mangle global locale name in Postgres setup
- Migrate from upstart userjobs for systemd user manager
