### PR TITLE
Add new nodejs versions and adapt rbenv vars.

### DIFF
--- a/ruby/rbenv/vars/Debian.yml
+++ b/ruby/rbenv/vars/Debian.yml
@@ -17,4 +17,4 @@ rbenv_package_names:
   - libgdbm-dev
 
 # only needed for ruby 2.1.1
-#rbenv_ruby_configure_opts: 'RUBY_CONFIGURE_OPTS=--with-readline-dir="/lib/{{ ansible_architecture }}-linux-gnu/libreadline.so.6"'
+rbenv_ruby_configure_opts: 'RUBY_CONFIGURE_OPTS=--with-readline-dir="/lib/{{ ansible_architecture }}-linux-gnu/libreadline.so.6"'

--- a/ruby/rbenv/vars/Debian.yml
+++ b/ruby/rbenv/vars/Debian.yml
@@ -17,4 +17,4 @@ rbenv_package_names:
   - libgdbm-dev
 
 # only needed for ruby 2.1.1
-rbenv_ruby_configure_opts: 'RUBY_CONFIGURE_OPTS=--with-readline-dir="/lib/{{ ansible_architecture }}-linux-gnu/libreadline.so.6"'
+#rbenv_ruby_configure_opts: 'RUBY_CONFIGURE_OPTS=--with-readline-dir="/lib/{{ ansible_architecture }}-linux-gnu/libreadline.so.6"'

--- a/yarn/defaults/main.yml
+++ b/yarn/defaults/main.yml
@@ -1,9 +1,13 @@
-nodejs_version: 'nodejs-v6x'
+nodejs_version: 'nodejs-v11x'
 
 nodejs_install:
 - build-essential
 
 nodejs_version_map:
+  nodejs-v11x: '11.x'
+  nodejs-v10x: '10.x'
+  nodejs-v9x: '9.x'
+  nodejs-v8x: '8.x'
   nodejs-v7x: '7.x'
   nodejs-v6x: '6.x'
   nodejs-v5x: '5.x'

--- a/yarn/defaults/main.yml
+++ b/yarn/defaults/main.yml
@@ -1,4 +1,4 @@
-nodejs_version: 'nodejs-v11x'
+nodejs_version: 'nodejs-v6x'
 
 nodejs_install:
 - build-essential


### PR DESCRIPTION
Added new nodejs versions into version map.
Lastly I adapted the rbenv vars so 'ruby/rbenv/vars/Debian.yml' behaves the same as 'ruby/rbenv/vars/RedHat.yml' and the special behavior for ruby v2.1.1 is commented by default.