### PR TITLE
Deprecation fixes for Ansible 2.7 - apk pkg

### DIFF
--- a/apache/passenger/tasks/apt_install.yml
+++ b/apache/passenger/tasks/apt_install.yml
@@ -10,12 +10,11 @@
 
 - name: install | packages
   apt:
-    pkg: "{{ item }}"
     state: "{{ apache_passenger_state }}"
     update_cache: yes
     cache_valid_time: 3600
-  with_items:
-  - "{{ apache_passenger_package }}"
+    pkg:
+    - "{{ apache_passenger_package }}"
   notify:
   - restart apache
 

--- a/apache/passenger/tasks/gem_install.yml
+++ b/apache/passenger/tasks/gem_install.yml
@@ -1,11 +1,10 @@
 ---
 - name: install dependencies
   apt:
-    pkg: "{{ item }}"
     state: present
     update_cache: yes
     cache_valid_time: 86400
-  with_items: "{{ apache_passenger_gem_packages }}"
+    pkg: "{{ apache_passenger_gem_packages }}"
 
 - name: install compatible rack version
   command: >

--- a/nginx/passenger/tasks/main.yml
+++ b/nginx/passenger/tasks/main.yml
@@ -3,17 +3,21 @@
   apt_key: url=http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x561F9B9CAC40B2F7 id=AC40B2F7 state=present
 
 - name: Apt | Add support for https
-  apt: pkg={{ item }} state=installed update_cache=yes cache_valid_time=3600
-  with_items:
-  - "apt-transport-https"
-  - "ca-certificates"
+  apt:
+    state: present
+    update_cache: yes
+    cache_valid_time: 3600
+    pkg:
+    - "apt-transport-https"
+    - "ca-certificates"
 
 - name: Apt | Add passenger repo
   apt_repository: repo='deb https://oss-binaries.phusionpassenger.com/apt/passenger {{ ansible_lsb.codename }} main' state=present update_cache=yes
 
 - name: Pkg | Install nginx passenger packages
-  apt: pkg={{ item }} state=installed
-  with_items:
+  apt:
+    state: present
+    pkg:
     - "nginx-extras"
     - "passenger"
   notify: nginx restart

--- a/rails/logrotate/tasks/Debian.yml
+++ b/rails/logrotate/tasks/Debian.yml
@@ -1,8 +1,7 @@
 ---
 - name: Debian | Packages
   apt:
-    pkg: "{{ item }}"
     update_cache: yes
     state: present
     cache_valid_time: 86400
-  with_items: "{{ logrotate_packages }}"
+    pkg: "{{ logrotate_packages }}"

--- a/ruby/mysql/tasks/main.yml
+++ b/ruby/mysql/tasks/main.yml
@@ -1,9 +1,8 @@
 # Packages required for mysql gem
 - name: Packages
   apt:
-    pkg: "{{item}}"
     update_cache: yes
     state: latest
     cache_valid_time: 86400
-  with_items:
-  - libmysqlclient-dev
+    pkg:
+    - libmysqlclient-dev

--- a/ruby/postgresql/tasks/Debian.yml
+++ b/ruby/postgresql/tasks/Debian.yml
@@ -1,8 +1,7 @@
 - name: Debian | Packages
   apt:
-    pkg: "{{ item }}"
     update_cache: yes
     state: latest
     cache_valid_time: 86400
-  with_items:
-  - libpq-dev
+    pkg:
+    - libpq-dev

--- a/ruby/rbenv/tasks/Debian-packages.yml
+++ b/ruby/rbenv/tasks/Debian-packages.yml
@@ -1,6 +1,5 @@
 - name: Debian | Install dependencies
   apt:
-    pkg: "{{ item }}"
     update_cache: yes
     state: latest
-  with_items: "{{ rbenv_package_names }}"
+    pkg: "{{ rbenv_package_names }}"

--- a/ruby/sqlite3/tasks/Debian.yml
+++ b/ruby/sqlite3/tasks/Debian.yml
@@ -1,8 +1,7 @@
 - name: Debian | Packages
   apt:
-    pkg: "{{ item }}"
     update_cache: yes
     state: latest
     cache_valid_time: 86400
-  with_items:
-  - libsqlite3-dev # build native sqlite3 driver
+    pkg:
+    - libsqlite3-dev # build native sqlite3 driver

--- a/yarn/tasks/nodejs.yml
+++ b/yarn/tasks/nodejs.yml
@@ -1,14 +1,12 @@
 - name: install dependencies
   apt:
-    name: "{{ item }}"
     update_cache: true
     cache_valid_time: 3600
-  with_items: "{{ nodejs_dependencies }}"
+    pkg: "{{ nodejs_dependencies }}"
 
 - name: install additional
   apt:
-    name: "{{ item }}"
-  with_items: "{{ nodejs_install }}"
+    pkg: "{{ nodejs_install }}"
 
 - name: add repository and install its signing key
   shell: curl -sL https://deb.nodesource.com/setup_{{ nodejs_version_map[nodejs_version] }} | bash -
@@ -17,6 +15,6 @@
 
 - name: install nodejs
   apt:
-    name: "{{ 'nodejs' if 'nodejs' in nodejs_version else 'iojs' }}"
+    pkg: "{{ 'nodejs' if 'nodejs' in nodejs_version else 'iojs' }}"
     update_cache: true
     state: latest


### PR DESCRIPTION
...first round of deprecations. There are still some left around the with_flattened. newest ansible shows some tips how to handle that:


> [DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is 
deprecated. Instead of using a loop to supply multiple items and specifying `pkg: "{{ item }}"`, 
please use 

```yaml
pkg: "{{ query('flattened', ['{{ imagemagick_packages }}', '{{ image_optimization_packages }}']) }}"
``` 

> and remove the loop. This feature will be removed in version 2.11. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
