### PR TITLE
New playbook: misc/clamav for clamav server + headless client

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Provisioning:
 * **firewalld** configure firewalld (for CentOS)
 * **selinux** currently only enable/disable selinux on CentOS
 * [**yarn**](https://github.com/dresden-weekly/ansible-rails/tree/develop/yarn) Installs nodejs + yarn (default nodejs-6.x)
+* [**clamav**](https://github.com/dresden-weekly/ansible-rails/tree/develop/clamav) Virus scanner daemon and frontend role
 
 Deployment:
 

--- a/misc/clamav/README.md
+++ b/misc/clamav/README.md
@@ -1,0 +1,25 @@
+# Installs clamav client and server
+
+Installs clamd, a frontend to a remote virus scanner. Clamd is memory heavy, so heaving one instance per app server is a bit huge. Running a single clamd server is preferrable.
+
+### Install server
+
+(needs currently ca. 1 GB RAM)
+
+```yaml
+- hosts: clamd
+  roles:
+   - role: dresden-weekly.rails/misc/clamav/server
+     clamd_port: 3310
+```
+
+If you are running in a public cloud environment, more steps for securing are useful (iptables, VPN, ...). Otherwise you might end up scanning for somebody else :).
+
+### Install client (inside rails / sidekiq vm provisioning)
+
+```yaml
+- role: dresden-weekly.rails/misc/clamav/client
+  clamd_host: 127.0.0.1
+  clamd_port: 3310
+  # clamd_host: "{{ hostvars['clamd.YOURSERVER.pludoni.com'].ansible_default_ipv4.address }}"
+```

--- a/misc/clamav/client/defaults/main.yml
+++ b/misc/clamav/client/defaults/main.yml
@@ -1,0 +1,2 @@
+clamd_port: 3310
+clamd_host: 127.0.0.1

--- a/misc/clamav/client/tasks/main.yml
+++ b/misc/clamav/client/tasks/main.yml
@@ -1,0 +1,11 @@
+- apt:
+    pkg: clamdscan
+    install_recommends: no
+  name: Install clamdscan (client only)
+  tags: [clamav]
+
+- template:
+    src: clamd.conf
+    dest: /etc/clamav/clamd.conf
+  name: Overriding clamd config (/etc/clamav/clamd.conf)
+  tags: [clamav]

--- a/misc/clamav/client/templates/clamd.conf
+++ b/misc/clamav/client/templates/clamd.conf
@@ -1,0 +1,4 @@
+# {{ansible_managed}}
+TCPSocket {{ clamd_port }}
+TCPAddr {{ clamd_host }}
+

--- a/misc/clamav/server/defaults/main.yml
+++ b/misc/clamav/server/defaults/main.yml
@@ -1,0 +1,1 @@
+clamav_port: 3310

--- a/misc/clamav/server/handlers/main.yml
+++ b/misc/clamav/server/handlers/main.yml
@@ -1,0 +1,9 @@
+- name: restart clamav-freshclam
+  service: name=clamav-freshclam state=restarted
+  listen: restart virus
+- name: restart clamav-daemon
+  service: name=clamav-daemon state=restarted
+  listen: restart virus
+- name: reload daemon
+  command: systemctl daemon-reload
+

--- a/misc/clamav/server/tasks/main.yml
+++ b/misc/clamav/server/tasks/main.yml
@@ -1,0 +1,26 @@
+- apt:
+    install_recommends: no
+    update_cache: yes
+    pkg:
+      - clamav-daemon
+      - clamav-freshclam
+      - libclamunrar7
+- lineinfile:
+    dest: /etc/clamav/clamd.conf
+    line: "TCPSocket {{clamav_port}}"
+  notify: restart virus
+- template:
+    src: 'socket'
+    dest: /lib/systemd/system/clamav-daemon.socket
+  notify: reload daemon
+- copy:
+    content: ""
+    dest: /etc/systemd/system/clamav-daemon.socket.d/extend.conf
+  notify: reload daemon
+  when: 'ansible_distribution_release == "xenial"'
+
+- name: trigger reload
+  command: /bin/true
+  notify:
+    - reload daemon
+    - restart virus

--- a/misc/clamav/server/templates/socket
+++ b/misc/clamav/server/templates/socket
@@ -1,0 +1,18 @@
+# {{ansible_managed}}
+[Unit]
+Description=Socket for Clam AntiVirus userspace daemon
+Documentation=man:clamd(8) man:clamd.conf(5) http://www.clamav.net/lang/en/doc/
+# Check for database existence
+ConditionPathExistsGlob=/var/lib/clamav/main.{c[vl]d,inc}
+ConditionPathExistsGlob=/var/lib/clamav/daily.{c[vl]d,inc}
+
+[Socket]
+ListenStream=/run/clamav/clamd.ctl
+ListenStream={{clamav_port}}
+SocketUser=clamav
+SocketGroup=clamav
+RemoveOnStop=True
+
+[Install]
+WantedBy=sockets.target
+


### PR DESCRIPTION
- headless clients - connects to a clamd main server
- server - dedicated VM of about 1GB RAM that scans files and holds the virus definition db


Remarks:

- we need virus scanning (user uploads, incoming mails etc) now for multiple apps, so it might be useful for other applications. A bit of a stretch for a general rails repo though
- Thus... folder /misc? Other ideas?
- server role is unsecured at the moment. As we running internal VMs we don't need network security. I've put a notice into the readme