### PR TITLE
Git export: create GIT_REVISION file into project root on create release

### DIFF
--- a/rails/create-release/defaults/main.yml
+++ b/rails/create-release/defaults/main.yml
@@ -3,6 +3,7 @@
 rails_release_id: "{{ rails_release_id_time }}"
 rails_release_id_time: "{{ [ansible_date_time.year, ansible_date_time.month, ansible_date_time.day, ansible_date_time.hour, ansible_date_time.minute, ansible_date_time.second] | join('') }}"
 rails_release_id_git_branch: "{{ git_branch }}"
+rails_release_create_git_version_file_name: "GIT_REVISION"
 
 # git repository where rails app taken from
 rails_app_git_repo: "{{ git_url }}"

--- a/rails/create-release/tasks/git.yml
+++ b/rails/create-release/tasks/git.yml
@@ -25,3 +25,13 @@
     chdir: "{{ rails_app_repo_path }}"
     warn: no # creating a release is a complex task that can not be done with the git module
   register: rails_create_release_result
+
+- name: Create GIT_REVISION file in project root
+  shell: >
+    git rev-parse {{ rails_app_git_branch }}
+    | tr -d '\n'
+    > {{ RAILS_APP_RELEASE_PATH }}/{{ rails_release_create_git_version_file_name }}
+  args:
+    chdir: "{{ rails_app_repo_path }}"
+    warn: no
+  when: rails_release_create_git_version_file_name is defined and rails_release_create_git_version_file_name


### PR DESCRIPTION
plain file with the deployed git commit hash.

Usecase: 
- Can be read on app boot / put into env variable, 
- for error tracking, logging etc. to reference the relevant git commit that caused an exception
- show version of installed software to user somewhere in ui

Other ideas for a name for that kind of file? Any best practice/standard name?